### PR TITLE
Adds helper_text example to storybook

### DIFF
--- a/src/components/FormTextField.tsx
+++ b/src/components/FormTextField.tsx
@@ -72,7 +72,7 @@ const FormTextField: React.SFC<FormTextFieldProps> = ({
             value={setValue}
             disabled={disabled}
             error={Boolean(meta.touched && meta.error)}
-            helperText={meta.touched ? meta.error : helperText || ''}
+            helperText={meta.touched ? meta.error || helperText : helperText || ''}
             InputProps={{
               endAdornment: (
                 <InputAdornment

--- a/stories/FormTextField.stories.tsx
+++ b/stories/FormTextField.stories.tsx
@@ -41,6 +41,13 @@ storiesOf('FormTextField', module)
               <FormTextField icon="stop" name="disabled" label="Disabled" disabled />
               <Divider variant="inset" />
               <FormTextField icon="notes" name="multiline" label="Multiline" multiline />
+              <Divider variant="inset" />
+              <FormTextField
+                icon="person"
+                name="helperText"
+                label="HelperText"
+                helperText="This is an example helper text"
+              />
             </React.Fragment>
           );
         }}


### PR DESCRIPTION
Fixes displaying helper_text after field is touched and when there is no error